### PR TITLE
ci: Add condition to skip validation for dependabot

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -18,6 +18,7 @@ jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       # Pinned to v5 commit hash for security
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5


### PR DESCRIPTION
This pull request introduces a small but important change to the GitHub Actions workflow for validating pull request titles. The workflow now excludes pull requests created by the `dependabot[bot]` user from semantic title validation.

* GitHub Actions workflow: Added a conditional (`if: github.actor != 'dependabot[bot]'`) to the `main` job in `.github/workflows/semantic-pull-request.yml` to skip validation for Dependabot PRs.