### PR TITLE
chore: suppress unused warnings in convention plugins and update exception documentation

### DIFF
--- a/build-logic/analysis-convention/src/main/kotlin/com/loomify/buildlogic/analysis/AppDetektPlugin.kt
+++ b/build-logic/analysis-convention/src/main/kotlin/com/loomify/buildlogic/analysis/AppDetektPlugin.kt
@@ -10,6 +10,7 @@ import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.register
 
+@Suppress("unused")
 internal class AppDetektPlugin : ConventionPlugin {
     override fun Project.configure() {
         apply(plugin = "io.gitlab.arturbosch.detekt")

--- a/build-logic/gradle-convention/src/main/kotlin/com/loomify/buildlogic/gradle/AppDependencyVersionsPlugin.kt
+++ b/build-logic/gradle-convention/src/main/kotlin/com/loomify/buildlogic/gradle/AppDependencyVersionsPlugin.kt
@@ -6,6 +6,7 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.withType
 
+@Suppress("unused")
 internal class AppDependencyVersionsPlugin : ConventionPlugin {
     private val stableKeywords = arrayOf("RELEASE", "FINAL", "GA")
     private val releaseRegex = "^[\\d,.v-]+(-r)?$".toRegex(RegexOption.IGNORE_CASE)

--- a/build-logic/gradle-convention/src/main/kotlin/com/loomify/buildlogic/gradle/AppKoverPlugin.kt
+++ b/build-logic/gradle-convention/src/main/kotlin/com/loomify/buildlogic/gradle/AppKoverPlugin.kt
@@ -11,6 +11,7 @@ import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.withType
 
+@Suppress("unused")
 internal class AppKoverPlugin : ConventionPlugin {
     private val classesExcludes = listOf(
         // Serializers

--- a/build-logic/library-convention/src/main/kotlin/com/loomify/buildlogic/library/LibraryConventionPlugin.kt
+++ b/build-logic/library-convention/src/main/kotlin/com/loomify/buildlogic/library/LibraryConventionPlugin.kt
@@ -9,6 +9,7 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.dependencies
 
+@Suppress("unused")
 class LibraryConventionPlugin : ConventionPlugin {
     override fun Project.configure() {
         apply(plugin = catalogPlugin("kotlin-jvm").get().pluginId)

--- a/build-logic/spring-boot-convention/src/main/kotlin/com/loomify/buildlogic/springboot/SpringBootConventionPlugin.kt
+++ b/build-logic/spring-boot-convention/src/main/kotlin/com/loomify/buildlogic/springboot/SpringBootConventionPlugin.kt
@@ -13,6 +13,7 @@ private const val TEST_IMPLEMENTATION = "testImplementation"
 
 private const val IMPLEMENTATION = "implementation"
 
+@Suppress("unused")
 class SpringBootConventionPlugin : ConventionPlugin {
     override fun Project.configure() {
         apply(plugin = catalogPlugin("kotlin-jvm").get().pluginId)

--- a/build-logic/spring-boot-convention/src/main/kotlin/com/loomify/buildlogic/springboot/SpringBootLibraryConventionPlugin.kt
+++ b/build-logic/spring-boot-convention/src/main/kotlin/com/loomify/buildlogic/springboot/SpringBootLibraryConventionPlugin.kt
@@ -11,6 +11,7 @@ import org.gradle.kotlin.dsl.dependencies
 
 private const val IMPLEMENTATION = "implementation"
 
+@Suppress("unused")
 class SpringBootLibraryConventionPlugin : ConventionPlugin {
     override fun Project.configure() {
         apply(plugin = catalogPlugin("kotlin-jvm").get().pluginId)

--- a/server/engine/src/main/kotlin/com/loomify/engine/controllers/GlobalExceptionHandler.kt
+++ b/server/engine/src/main/kotlin/com/loomify/engine/controllers/GlobalExceptionHandler.kt
@@ -172,7 +172,7 @@ class GlobalExceptionHandler(
         ex: WebExchangeBindException,
         headers: org.springframework.http.HttpHeaders,
         status: org.springframework.http.HttpStatusCode,
-        exchange: org.springframework.web.server.ServerWebExchange,
+        exchange: ServerWebExchange,
     ): Mono<org.springframework.http.ResponseEntity<Any>> {
         val localizedMessage = getLocalizedMessage(exchange, MSG_VALIDATION_ERROR)
 

--- a/server/engine/src/main/kotlin/com/loomify/resume/domain/model/WorkExperience.kt
+++ b/server/engine/src/main/kotlin/com/loomify/resume/domain/model/WorkExperience.kt
@@ -43,7 +43,7 @@ value class Highlight(val value: String) {
  * - `startDate`: Must parse as valid ISO-8601 date
  * - `endDate`: If present, must parse and be ≥ `startDate`
  * - Throws [IllegalArgumentException] on chronology violations
- * - Throws [DateTimeParseException] on malformed date strings
+ * - Throws [java.time.format.DateTimeParseException] on malformed date strings
  *
  * ## Example JSON Payload
  * ```json
@@ -72,7 +72,7 @@ value class Highlight(val value: String) {
  * @property url Company website [Url] value object (optional)
  *
  * @throws IllegalArgumentException If end date precedes start date
- * @throws DateTimeParseException If date strings aren't valid ISO-8601 format
+ * @throws java.time.format.DateTimeParseException If date strings aren't valid ISO-8601 format
  */
 data class WorkExperience(
     val name: CompanyName,


### PR DESCRIPTION
This pull request primarily adds the `@Suppress("unused")` annotation to several Gradle convention plugin classes to prevent unused code warnings, and makes minor documentation and import cleanup in the Kotlin codebase. These changes help improve code quality and maintainability by reducing unnecessary warnings and clarifying exception types.

**Gradle plugin annotations:**

* Added `@Suppress("unused")` annotation to the following convention plugin classes to suppress unused code warnings: `AppDetektPlugin`, `AppDependencyVersionsPlugin`, `AppKoverPlugin`, `LibraryConventionPlugin`, `SpringBootConventionPlugin`, and `SpringBootLibraryConventionPlugin`. [[1]](diffhunk://#diff-593df8fad4046657c34585d3acbc6e493ed16e4aeb08695e6c62922bf1423beaR13) [[2]](diffhunk://#diff-59c76651e8ba80d7dd119ab6acee87af6da804a56c71f4aab7cb17203129ec23R9) [[3]](diffhunk://#diff-3eb1ad08a5a3d45a233a70d899d74c47c647a68b7872673aac000f94363d0314R14) [[4]](diffhunk://#diff-b489ade41b10bc08af847bd5a4bdbdc948ff360caa68ab86a44a85c4069a99adR12) [[5]](diffhunk://#diff-fc9dbb06d109cc3845c26674fa47fc7da4e8fc4d84509f06224b4e318c535342R16) [[6]](diffhunk://#diff-caec461d11bca0cf7346203c4a2488012fe7ba07589026c7cb74926a2294d99eR14)

**Documentation improvements:**

* Updated documentation in `WorkExperience.kt` to specify the fully qualified exception type `java.time.format.DateTimeParseException` for malformed date strings, improving clarity for consumers of the API. [[1]](diffhunk://#diff-42ee123caaeb8763ff55fe8d9495ad906c6ead8254528502d739cc1b2eee6180L46-R46) [[2]](diffhunk://#diff-42ee123caaeb8763ff55fe8d9495ad906c6ead8254528502d739cc1b2eee6180L75-R75)

**Minor code cleanup:**

* Simplified the import for `ServerWebExchange` in `GlobalExceptionHandler.kt` to use the direct class reference, reducing verbosity.