### PR TITLE
fix(ci): adjust concurrency group for PR title linting

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -11,7 +11,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
The `semantic-pull-request` workflow was using `github.ref` as part of its concurrency group. When triggered by `pull_request_target`, `github.ref` refers to the base branch (e.g., `main`), causing all pull requests to share the same concurrency group. This resulted in workflows being canceled whenever a new PR was opened or updated.

To resolve this, the concurrency group has been updated to use `github.event.pull_request.number`, ensuring that each pull request has a unique concurrency group. This prevents unrelated workflows from being canceled and allows them to run in parallel without interfering with each other.