### PR TITLE
ci: Add slug and token to Codecov action

### DIFF
--- a/.github/actions/codecov/action.yml
+++ b/.github/actions/codecov/action.yml
@@ -32,6 +32,8 @@ runs:
         files: ${{ inputs.files }}
         flags: ${{ inputs.flags }}
         name: ${{ inputs.name }}
+        slug: dallay/cvix
+        token: ${{ inputs.codecov-token }}
         fail_ci_if_error: ${{ inputs.fail-ci-if-error }}
       env:
         CODECOV_TOKEN: ${{ inputs.codecov-token }}


### PR DESCRIPTION
This pull request updates the Codecov GitHub Action configuration to improve reliability and ensure proper repository identification. The most important changes are:

Codecov Action configuration:

* Added the `slug: dallay/cvix` parameter to explicitly specify the repository for Codecov uploads, which helps prevent misattribution of coverage reports.
* Added the `token: ${{ inputs.codecov-token }}` parameter to ensure the Codecov upload uses the correct authentication token, improving security and reliability.