### PR TITLE
chore(deps): update Docker Buildx action to latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -542,16 +542,18 @@ jobs:
       - name: Summary
         if: always()
         run: |
-          echo "## CI Pipeline Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Job | Status |" >> $GITHUB_STEP_SUMMARY
-          echo "|-----|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Changes Detection | ${{ needs.changes.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Lint Meta | ${{ needs.lint-meta.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Lint Markdown | ${{ needs.lint-markdown.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Backend Lint | ${{ needs.lint-backend.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Backend Pipeline | ${{ needs.backend-pipeline.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Frontend Lint | ${{ needs.lint-frontend.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Frontend Pipeline | ${{ needs.frontend-pipeline.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Security Scans | ${{ needs.security-scans.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Coverage Verification | ${{ needs.coverage-verification.result }} |" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## CI Pipeline Summary"
+            echo ""
+            echo "| Job | Status |"
+            echo "|-----|--------|"
+            echo "| Changes Detection | ${{ needs.changes.result }} |"
+            echo "| Lint Meta | ${{ needs.lint-meta.result }} |"
+            echo "| Lint Markdown | ${{ needs.lint-markdown.result }} |"
+            echo "| Backend Lint | ${{ needs.lint-backend.result }} |"
+            echo "| Backend Pipeline | ${{ needs.backend-pipeline.result }} |"
+            echo "| Frontend Lint | ${{ needs.lint-frontend.result }} |"
+            echo "| Frontend Pipeline | ${{ needs.frontend-pipeline.result }} |"
+            echo "| Security Scans | ${{ needs.security-scans.result }} |"
+            echo "| Coverage Verification | ${{ needs.coverage-verification.result }} |"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
This pull request updates the Docker Buildx setup step in the CI workflow configuration. The change replaces the commit hash for the `docker/setup-buildx-action` GitHub Action to a newer version, ensuring the workflow uses the latest available code for this action.

* Updated the `uses` reference for `docker/setup-buildx-action` to commit `4fd812986e6c8c2a69e18311145f9371337f27d4` across all relevant jobs in `.github/workflows/ci.yml`. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL353-R353) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL390-R390) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL427-R427)