### PR TITLE
fix(deps): update deprecated Bucket4j API usage

### DIFF
--- a/server/engine/src/main/kotlin/com/loomify/engine/ratelimit/infrastructure/PricingPlan.kt
+++ b/server/engine/src/main/kotlin/com/loomify/engine/ratelimit/infrastructure/PricingPlan.kt
@@ -9,22 +9,25 @@ import java.time.Duration
  */
 enum class PricingPlan {
     FREE {
-        override fun getLimit(): Bandwidth = Bandwidth.simple(
-            FREE_REFILL_TOKENS,
-            Duration.ofHours(REFILL_HOURS),
-        ).withInitialTokens(FREE_CAPACITY)
+        override fun getLimit(): Bandwidth = Bandwidth.builder()
+            .capacity(FREE_CAPACITY)
+            .refillGreedy(FREE_REFILL_TOKENS, Duration.ofHours(REFILL_HOURS))
+            .initialTokens(FREE_CAPACITY)
+            .build()
     },
     BASIC {
-        override fun getLimit(): Bandwidth = Bandwidth.simple(
-            BASIC_REFILL_TOKENS,
-            Duration.ofHours(REFILL_HOURS),
-        ).withInitialTokens(BASIC_CAPACITY)
+        override fun getLimit(): Bandwidth = Bandwidth.builder()
+            .capacity(BASIC_CAPACITY)
+            .refillGreedy(BASIC_REFILL_TOKENS, Duration.ofHours(REFILL_HOURS))
+            .initialTokens(BASIC_CAPACITY)
+            .build()
     },
     PROFESSIONAL {
-        override fun getLimit(): Bandwidth = Bandwidth.simple(
-            PROFESSIONAL_REFILL_TOKENS,
-            Duration.ofHours(REFILL_HOURS),
-        ).withInitialTokens(PROFESSIONAL_CAPACITY)
+        override fun getLimit(): Bandwidth = Bandwidth.builder()
+            .capacity(PROFESSIONAL_CAPACITY)
+            .refillGreedy(PROFESSIONAL_REFILL_TOKENS, Duration.ofHours(REFILL_HOURS))
+            .initialTokens(PROFESSIONAL_CAPACITY)
+            .build()
     };
 
     abstract fun getLimit(): Bandwidth

--- a/server/engine/src/main/kotlin/com/loomify/engine/ratelimit/infrastructure/config/BucketConfigurationStrategy.kt
+++ b/server/engine/src/main/kotlin/com/loomify/engine/ratelimit/infrastructure/config/BucketConfigurationStrategy.kt
@@ -86,9 +86,12 @@ class BucketConfigurationStrategy(
      * @return A [Bandwidth] instance configured with the specified parameters.
      */
     private fun createBandwidth(limit: RateLimitProperties.BandwidthLimit): Bandwidth {
-        // Bucket4j v8 uses a fluent API to build bandwidths
-        return Bandwidth.simple(limit.refillTokens, limit.refillDuration)
-            .withInitialTokens(limit.capacity)
+        // Updated to use Bucket4j v8 builder API (no deprecated methods)
+        return Bandwidth.builder()
+            .capacity(limit.capacity)
+            .refillGreedy(limit.refillTokens, limit.refillDuration)
+            .initialTokens(limit.capacity)
+            .build()
     }
 
     /**


### PR DESCRIPTION
Replaced deprecated `Bandwidth.classic` and `Refill` with the modern fluent `Bandwidth.simple` API to resolve build warnings and align with the latest library version.

