### PR TITLE
ci: Exclude CHANGELOG.md from markdown linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
             !node_modules/**
             !dist/**
             !build/**
+            !CHANGELOG.md
           config: .markdownlint.json
 
   # ============================================================================


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow configuration. The change ensures that the `CHANGELOG.md` file is excluded from the list of ignored files for the markdown linting job, so changes to this file will now trigger markdown linting as expected.