### PR TITLE
chore: kotlin map null-safety (#437)

### DIFF
--- a/server/engine/src/main/kotlin/com/cvix/resume/infrastructure/template/source/TemplateSourceRepositoryFactory.kt
+++ b/server/engine/src/main/kotlin/com/cvix/resume/infrastructure/template/source/TemplateSourceRepositoryFactory.kt
@@ -125,7 +125,7 @@ class TemplateSourceRepositoryFactory(
                 TemplateSourceType.CLASSPATH -> TemplateSourceKeys.CLASSPATH
                 TemplateSourceType.FILESYSTEM -> TemplateSourceKeys.FILESYSTEM
             }
-            val repository = templateSources[repositoryBeanName]!!
+            val repository = templateSources.getValue(repositoryBeanName)
             log.info(
                 "Activated template repository: {} (type: {})",
                 repositoryBeanName,


### PR DESCRIPTION
* chore: kotlin map null-safety, avoiding ./gradlew detektAll in map access

* fix: simplify repository retrieval in TemplateSourceRepositoryFactory