### PR TITLE
fix(webapp): add CSP_OBJECT_SRC for PDF blob preview

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,9 +92,12 @@ CORS_MAX_AGE=3600
 # CSP_CONNECT_SRC: Allowed origins for fetch/XHR/WebSocket connections.
 #   Include 'self', your backend API URL, and auth provider (Keycloak).
 #   Example: 'self' https://api.example.com https://auth.example.com
+# CSP_OBJECT_SRC: Allowed sources for <object>, <embed>, <applet> elements.
+#   Use 'self' blob: to allow PDF preview with blob URLs, or 'none' for strict security.
 CSP_SCRIPT_SRC="'self' 'unsafe-inline'"
 CSP_STYLE_SRC="'self' 'unsafe-inline'"
 CSP_CONNECT_SRC="'self' https://api.example.com https://auth.example.com"
+CSP_OBJECT_SRC="'self' blob:"
 
 # ----------------------------
 # Service Versions & Helpers

--- a/client/apps/webapp/Dockerfile
+++ b/client/apps/webapp/Dockerfile
@@ -85,10 +85,12 @@ COPY --from=build --chown=nginx:nginx /app/client/apps/webapp/dist /usr/share/ng
 #   CSP_SCRIPT_SRC: 'self' 'sha256-HASH1' 'sha256-HASH2' (remove 'unsafe-inline')
 #   CSP_STYLE_SRC: 'self' 'sha256-HASH1' (remove 'unsafe-inline')
 #   CSP_CONNECT_SRC: 'self' https://api.yourdomain.com https://auth.yourdomain.com
+#   CSP_OBJECT_SRC: 'self' blob: (for PDF preview), or 'none' for strict security
 ENV BACKEND_URL=https://backend.localhost \
     CSP_SCRIPT_SRC="'self' 'unsafe-inline'" \
     CSP_STYLE_SRC="'self' 'unsafe-inline'" \
-    CSP_CONNECT_SRC="'self' https://backend.localhost"
+    CSP_CONNECT_SRC="'self' https://backend.localhost" \
+    CSP_OBJECT_SRC="'self' blob:"
 
 # Expose port 8080 (non-privileged port, nginx-unprivileged default)
 EXPOSE 8080

--- a/client/apps/webapp/docker-entrypoint.sh
+++ b/client/apps/webapp/docker-entrypoint.sh
@@ -25,6 +25,7 @@ MISSING_VARS=""
 [ -z "$CSP_SCRIPT_SRC" ] && MISSING_VARS="$MISSING_VARS CSP_SCRIPT_SRC"
 [ -z "$CSP_STYLE_SRC" ] && MISSING_VARS="$MISSING_VARS CSP_STYLE_SRC"
 [ -z "$CSP_CONNECT_SRC" ] && MISSING_VARS="$MISSING_VARS CSP_CONNECT_SRC"
+[ -z "$CSP_OBJECT_SRC" ] && MISSING_VARS="$MISSING_VARS CSP_OBJECT_SRC"
 
 if [ -n "$MISSING_VARS" ]; then
   echo "❌ ERROR: Required environment variables are not set:$MISSING_VARS" >&2
@@ -34,6 +35,7 @@ if [ -n "$MISSING_VARS" ]; then
   echo "  CSP_SCRIPT_SRC    - CSP script-src directive (e.g., 'self' 'unsafe-inline')" >&2
   echo "  CSP_STYLE_SRC     - CSP style-src directive (e.g., 'self' 'unsafe-inline')" >&2
   echo "  CSP_CONNECT_SRC   - CSP connect-src directive (e.g., 'self' https://api.example.com)" >&2
+  echo "  CSP_OBJECT_SRC    - CSP object-src directive (e.g., 'self' blob: for PDF preview)" >&2
   echo "" >&2
   echo "See Dockerfile ENV section or infra/.env.example for defaults." >&2
   exit 1
@@ -44,10 +46,11 @@ echo "   BACKEND_URL: $BACKEND_URL"
 echo "   CSP_SCRIPT_SRC: $CSP_SCRIPT_SRC"
 echo "   CSP_STYLE_SRC: $CSP_STYLE_SRC"
 echo "   CSP_CONNECT_SRC: $CSP_CONNECT_SRC"
+echo "   CSP_OBJECT_SRC: $CSP_OBJECT_SRC"
 
 echo "Substituting environment variables in nginx configuration..."
-envsubst '${BACKEND_URL} ${CSP_SCRIPT_SRC} ${CSP_STYLE_SRC} ${CSP_CONNECT_SRC}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
-envsubst '${BACKEND_URL} ${CSP_SCRIPT_SRC} ${CSP_STYLE_SRC} ${CSP_CONNECT_SRC}' < /etc/nginx/conf.d/security-headers.conf.template > /etc/nginx/conf.d/security-headers.conf
+envsubst '${BACKEND_URL} ${CSP_SCRIPT_SRC} ${CSP_STYLE_SRC} ${CSP_CONNECT_SRC} ${CSP_OBJECT_SRC}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+envsubst '${BACKEND_URL} ${CSP_SCRIPT_SRC} ${CSP_STYLE_SRC} ${CSP_CONNECT_SRC} ${CSP_OBJECT_SRC}' < /etc/nginx/conf.d/security-headers.conf.template > /etc/nginx/conf.d/security-headers.conf
 
 echo "✅ Configuration files generated successfully"
 

--- a/client/apps/webapp/security-headers.conf.template
+++ b/client/apps/webapp/security-headers.conf.template
@@ -6,10 +6,12 @@
 #   - CSP_STYLE_SRC: CSP style-src directive (e.g., 'self' 'sha256-...')
 #   - CSP_CONNECT_SRC: CSP connect-src directive for allowed fetch/XHR/WebSocket origins
 #                      (e.g., 'self' https://api.example.com https://auth.example.com)
+#   - CSP_OBJECT_SRC: CSP object-src directive for <object>, <embed>, <applet> elements
+#                     (e.g., 'none' for maximum security, or 'self' blob: for PDF preview)
 
 add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-add_header Content-Security-Policy "default-src 'self'; script-src ${CSP_SCRIPT_SRC}; style-src ${CSP_STYLE_SRC}; img-src 'self' data: https:; font-src 'self' data:; connect-src ${CSP_CONNECT_SRC}; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self'" always;
+add_header Content-Security-Policy "default-src 'self'; script-src ${CSP_SCRIPT_SRC}; style-src ${CSP_STYLE_SRC}; img-src 'self' data: https:; font-src 'self' data:; connect-src ${CSP_CONNECT_SRC}; frame-ancestors 'self'; object-src ${CSP_OBJECT_SRC}; base-uri 'self'; form-action 'self'" always;
 add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;


### PR DESCRIPTION
## Summary
- Add `CSP_OBJECT_SRC` environment variable to allow `'self' blob:` for PDF preview
- Fixes CSP `object-src 'none'` directive blocking PDF preview using `<object>` tag with blob URLs

## Problem
The PDF preview in the Resume Generator page uses `<object type="application/pdf">` with a blob URL created by `URL.createObjectURL()`. The previous CSP policy had `object-src 'none'` which blocked this.

## Solution
Make `object-src` configurable via `CSP_OBJECT_SRC` environment variable, defaulting to `'self' blob:` to allow PDF blob URLs while maintaining security.

## Changes
- `security-headers.conf.template`: Use `${CSP_OBJECT_SRC}` instead of hardcoded `'none'`
- `docker-entrypoint.sh`: Validate and substitute `CSP_OBJECT_SRC`
- `Dockerfile`: Add default `CSP_OBJECT_SRC="'self' blob:"`
- `.env.example`: Document the new variable

## Deployment
After merging, set in Dokploy:
```
CSP_OBJECT_SRC="'self' blob:"
```