### PR TITLE
docs: add llm txt

### DIFF
--- a/client/apps/marketing/src/pages/llms.txt.ts
+++ b/client/apps/marketing/src/pages/llms.txt.ts
@@ -30,6 +30,7 @@ function generatePageList(
 			frontmatter: page.frontmatter,
 			slug: path.split("/").pop()?.replace(".mdx", "") ?? "",
 		}))
+		.filter(({ slug }) => slug.length > 0)
 		.filter(({ frontmatter }) => hasTitleAndDescription(frontmatter))
 		.map(({ frontmatter, slug }) => {
 			const pageUrl = new URL(`${lang}/${slug}`, siteUrl).toString();
@@ -50,7 +51,12 @@ export const GET: APIRoute = async () => {
 	const pagesRecord = await import.meta.glob("./(en|es)/*.mdx", {
 		eager: true,
 	});
-	const pages = Object.entries(pagesRecord) as [string, MdxPageModule][];
+	const pages = Object.entries(pagesRecord).filter(
+		(entry): entry is [string, MdxPageModule] =>
+			typeof entry[1] === "object" &&
+			entry[1] !== null &&
+			"frontmatter" in entry[1],
+	);
 
 	const lines = [
 		"# ProFileTailors",


### PR DESCRIPTION
This pull request adds a new API route to the marketing client that generates a plain text listing of available English and Spanish pages for the ProFileTailors site. The route dynamically discovers `.mdx` pages, extracts metadata, and formats a language-specific list with titles, URLs, and descriptions.

API Route Addition:

* Introduced a new Astro API route (`llms.txt.ts`) that returns a plain text summary of English and Spanish content pages, including their titles, URLs, and descriptions.
* Implemented the `generatePageList` helper function to filter and format pages based on language and metadata, ensuring only pages with both a title and description are included.