### PR TITLE
fix(marketing): repair broken internal and email links

### DIFF
--- a/client/apps/marketing/src/pages/en/about.mdx
+++ b/client/apps/marketing/src/pages/en/about.mdx
@@ -39,5 +39,5 @@ Customize your profile and resume with ease. Join our early access list below an
 />
 
 <p class="text-sm text-gray-500 mt-2">
-  Review our <a href="/privacy-policy" class="underline">Privacy Policy</a> and <a href="/terms-of-use" class="underline">Terms of Use</a> for important information about how your data is handled.
+  Review our <a href="/en/privacy-policy" class="underline">Privacy Policy</a> and <a href="/en/terms-of-use" class="underline">Terms of Use</a> for important information about how your data is handled.
 </p>

--- a/client/apps/marketing/src/pages/en/privacy-policy.mdx
+++ b/client/apps/marketing/src/pages/en/privacy-policy.mdx
@@ -34,4 +34,4 @@ We keep your information only as long as necessary to provide our services or me
 
 ## Contact Us
 
-If you have questions about this privacy policy or your personal data, please contact us at [profiletailors+support@gmail.com].
+If you have questions about this privacy policy or your personal data, please contact us at [profiletailors+support@gmail.com](mailto:profiletailors+support@gmail.com).

--- a/client/apps/marketing/src/pages/en/support.mdx
+++ b/client/apps/marketing/src/pages/en/support.mdx
@@ -26,7 +26,7 @@ We welcome suggestions and feedback. Tell us what improvements or new features y
 
 ## Contact Channels
 
-- Email support: [profiletailors+support@gmail.com]
+- Email support: [profiletailors+support@gmail.com](mailto:profiletailors+support@gmail.com)
 - Live chat: available on our website during business hours
 
 We respond to most queries within one business day.

--- a/client/apps/marketing/src/pages/es/privacy-policy.mdx
+++ b/client/apps/marketing/src/pages/es/privacy-policy.mdx
@@ -34,4 +34,4 @@ Guardamos tu información solo el tiempo necesario para prestar nuestros servici
 
 ## Contáctanos
 
-Si tienes dudas acerca de esta política de privacidad o de tus datos personales, escríbenos a [profiletailors+support@gmail.com].
+Si tienes dudas acerca de esta política de privacidad o de tus datos personales, escríbenos a [profiletailors+support@gmail.com](mailto:profiletailors+support@gmail.com).

--- a/client/apps/marketing/src/pages/es/support.mdx
+++ b/client/apps/marketing/src/pages/es/support.mdx
@@ -26,7 +26,7 @@ Tus sugerencias son bienvenidas. Cuéntanos qué mejoras o nuevas funciones te g
 
 ## Canales de contacto
 
-- Soporte por correo: [profiletailors+support@gmail.com]
+- Soporte por correo: [profiletailors+support@gmail.com](mailto:profiletailors+support@gmail.com)
 - Chat en vivo: disponible en el sitio web durante el horario laboral
 
 Respondemos la mayoría de las consultas en un día hábil.


### PR DESCRIPTION
Repairs multiple broken links across the marketing site to improve SEO and user experience.

- Updates mailto links on contact, support, and privacy pages to prevent Cloudflare email obfuscation from creating 404s.
- Corrects internal links on the about page to point to language-specific versions of the privacy policy and terms of use.