### PR TITLE
fix(security): 🛡️ harden management endpoints and fix secret scanner

### DIFF
--- a/scripts/check-secrets.sh
+++ b/scripts/check-secrets.sh
@@ -13,13 +13,14 @@ GITLEAKS_VERSION="8.30.0"
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 ARCH="$(uname -m)"
 case "$ARCH" in
-  x86_64) ARCH="amd64" ;;
+  x86_64) ARCH="x64" ;;
   aarch64 | arm64) ARCH="arm64" ;;
   *) echo -e "${RED}❌ Unsupported architecture: $ARCH${RESET}" >&2; exit 1 ;;
 esac
 
 TARBALL="gitleaks_${GITLEAKS_VERSION}_${OS}_${ARCH}.tar.gz"
-CHECKSUMS_URL="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/checksums.txt"
+CHECKSUMS_FILE="gitleaks_${GITLEAKS_VERSION}_checksums.txt"
+CHECKSUMS_URL="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${CHECKSUMS_FILE}"
 TARBALL_URL="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${TARBALL}"
 
 INSTALL_DIR="$HOME/.local/bin"
@@ -29,7 +30,7 @@ if ! command -v gitleaks >/dev/null 2>&1; then
   echo -e "${YELLOW}🔍 gitleaks not found, installing to $INSTALL_DIR...${RESET}"
   curl -sSL -O "$TARBALL_URL"
   curl -sSL -O "$CHECKSUMS_URL"
-  grep "$TARBALL" checksums.txt > "${TARBALL}.sha256"
+  grep "$TARBALL" "$CHECKSUMS_FILE" > "${TARBALL}.sha256"
   sha256sum -c "${TARBALL}.sha256"
   tar -xzf "$TARBALL" gitleaks
   mv gitleaks "$INSTALL_DIR/"

--- a/server/modules/identity/identity-infrastructure/src/main/kotlin/com/cvix/identity/infrastructure/authentication/SecurityConfiguration.kt
+++ b/server/modules/identity/identity-infrastructure/src/main/kotlin/com/cvix/identity/infrastructure/authentication/SecurityConfiguration.kt
@@ -202,7 +202,6 @@ class SecurityConfiguration(
                 "/api/auth/refresh-token", "/api/auth/login", "/api/auth/logout",
                 "/api/auth/csrf",
                 "/api/auth/federated/**", "/oauth2/**", "/login/oauth2/**",
-                "actuator/info",
             ).permitAll()
             .pathMatchers(
                 "/swagger-ui/**", "/webjars/**", "/api-docs/**", "/swagger-ui.html",
@@ -216,8 +215,6 @@ class SecurityConfiguration(
             .pathMatchers("/actuator/**").authenticated()
             .pathMatchers("/api/**").authenticated()
             .pathMatchers("/management/health").permitAll()
-            .pathMatchers("/management/info").permitAll()
-            .pathMatchers("/management/prometheus").permitAll()
             .pathMatchers("/management/**").hasAuthority(Role.ADMIN.key())
     }
 


### PR DESCRIPTION
This PR addresses two security-related issues:
1. **Actuator Endpoint Exposure**: The `/management/info` and `/management/prometheus` endpoints were previously configured with `permitAll()`, exposing internal metrics and build information to unauthorized users. These have been restricted to the `ADMIN` role.
2. **Broken Secret Scanner**: The `scripts/check-secrets.sh` script was failing to install `gitleaks` due to an incorrect architecture mapping and a missing checksum file. This has been fixed to ensure secret scanning is functional in the CI/CD pipeline.

All changes are well within the 50-line limit for Sentinel tasks. Verification was performed using `make _verify-backend-check` and `make _verify-secrets`.

---
*PR created automatically by Jules for task [16328807985855626231](https://jules.google.com/task/16328807985855626231) started by @yacosta738*